### PR TITLE
Updated Beanie support to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
 ---
+## 0.0.2beta1 (2025-07-25)
+
+### Added
+- Support for Beanie 2.0.0
+- Updated CHANGELOG.md
+
+### Todo
+- Create a proper README/Documentation
+
+### Compatibility
+- Tested with
+  - starlette-admin (0.15.1)
+  - Beanie-ODM (2.0.0)
+  - FastAPI (0.116.1)
+
+---
 ## 0.0.1beta3 (2025-06-26)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "starlette-admin-beanie-backend"
-version = "0.0.1beta3"
+version = "0.0.2beta1"
 description = "Unofficial Beanie-ODM support for Starlette Admin"
 readme = "README.md"
 authors = [{ name = "Arnab Jain", email = "arnab@inocentum.in" }]
@@ -27,9 +27,9 @@ classifiers = [
 ]
 dependencies = [
     "starlette-admin>=0.15.0",
-    "beanie>=1.29.0"
+    "beanie>=2.0.0"
 ]
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.9,<3.14"
 
 [project.urls]
 Homepage = "https://github.com/arnabJ/starlette-admin-beanie-backend"

--- a/starlette_admin_beanie_backend/converters.py
+++ b/starlette_admin_beanie_backend/converters.py
@@ -1,4 +1,4 @@
-from typing import Any, Sequence, Type, get_args, get_origin, Union
+from typing import Any, Sequence, Type, get_args, get_origin
 from uuid import UUID
 
 import bson

--- a/starlette_admin_beanie_backend/view.py
+++ b/starlette_admin_beanie_backend/view.py
@@ -75,10 +75,10 @@ class ModelView(BaseModelView):
 
     async def count(self, request: Request, where: Union[Dict[str, Any], str, None] = None) -> int:
         if where is None:
-            return await self.model.get_motor_collection().estimated_document_count()
+            return await self.model.get_pymongo_collection().estimated_document_count()
 
         q = await self._build_query(request, where)
-        return await self.model.get_motor_collection().count_documents(q)
+        return await self.model.get_pymongo_collection().count_documents(q)
 
     async def find_by_pk(self, request: Request, pk: Any) -> Any:
         return await self.model.get(pk, fetch_links=True)


### PR DESCRIPTION
Tested with latest FastAPI version (at the time of release of this update) Bumped version to 0.0.2beta1